### PR TITLE
Mention HA Addons in out of scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ The app will not support multiple devices. You can run multiple instances of the
 
 Docker is the only supported way of deploying the application. The app should run directly via Python but this is not supported.
 
+### Home Assistant Addons
+
+There are a couple of Home Assistant Addons that use my code to be able to port this software into Supervised versions of Home Assistant. I do not specifically support the add-ons themselves, only the base software in the original docker format. Please contact the authors of those add-ons for support if using that method.
+
+https://github.com/ikifar2012/amcrest2mqtt-addon/blob/master/README.md
+[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fikifar2012%2Fha-addons)
+
+https://github.com/dchesterton/amcrest2mqtt/blob/main/README.md
+[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Frobsonke%2Fhassio-addons)
+
 ## Buy Me A ~~Coffee~~ Beer 🍻
 
 A few people have kindly requested a way to donate a small amount of money. If you feel so inclined I've set up a "Buy Me A Coffee"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ There are a couple of Home Assistant Addons that use my code to be able to port 
 https://github.com/ikifar2012/amcrest2mqtt-addon/blob/master/README.md
 [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fikifar2012%2Fha-addons)
 
-https://github.com/dchesterton/amcrest2mqtt/blob/main/README.md
+https://github.com/robsonke/hassio-addons/blob/master/amcrest2mqtt/README.md
 [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Frobsonke%2Fhassio-addons)
 
 ## Buy Me A ~~Coffee~~ Beer 🍻


### PR DESCRIPTION
A suggestion for an edit in your readme.md.
This shifts responsibility to the add-on repo owners, but still informs people so you can close your oldest issue and not have to answer the same question over and over.