### PR TITLE
Push docker image to ghcr.io as well

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     docker-publish:
-        name: Publish to Docker Hub
+        name: Publish to Docker Hub and GitHub Container Registry
         if: "!contains(github.event.head_commit.message, '[ci skip]')"
         runs-on: ubuntu-20.04
         steps:
@@ -35,6 +35,12 @@ jobs:
               with:
                   username: ${{ secrets.DOCKER_USERNAME }}
                   password: ${{ secrets.DOCKER_PASSWORD }}
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v1.14.1
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.repository_owner }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
             - name: Build and push
               uses: docker/build-push-action@v2.10.0
               with:
@@ -44,4 +50,6 @@ jobs:
                   tags: |
                       dchesterton/amcrest2mqtt:latest
                       dchesterton/amcrest2mqtt:${{ steps.version.outputs.version }}
+                      ghcr.io/dchesterton/amcrest2mqtt:latest
+                      ghcr.io/dchesterton/amcrest2mqtt:${{ steps.version.outputs.version }}
                   labels: "version=${{ steps.version.outputs.version }}"


### PR DESCRIPTION
This PR updates the github workflow to push the docker images to Github Container Registry (ghcr.io) as well as Docker Hub.

The main advantage of ghcr is that it doesn't have any pull limits for the users like Docker Hub now does: https://docs.docker.com/docker-hub/download-rate-limit/