### PR TITLE
Catch ValueError exception

### DIFF
--- a/src/amcrest2mqtt.py
+++ b/src/amcrest2mqtt.py
@@ -102,7 +102,12 @@ def refresh_storage_sensors():
         log(f"Error fetching storage information {error}", level="WARNING")
 
 def to_gb(total):
-    return str(round(float(total[0]) / 1024 / 1024 / 1024, 2))
+    try:
+        return str(round(float(total[0]) / 1024 / 1024 / 1024, 2))
+    except ValueError as error:
+        # the api sometimes returns the string "unknown" instead of a number
+        log(f"Unexpected error: {error}", level="WARNING")
+        return 0
 
 def signal_handler(sig, frame):
     # exit immediately upon receiving a second SIGINT


### PR DESCRIPTION
The api seems to return a string in some cases, which seems to happen just after boot of the camera.